### PR TITLE
Get FreeBSD build working.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,17 +38,15 @@ task:
       container:
         image: alpine:edge # TODO: use alpine:3.15 or newest stable release when available
 
-    # TODO: Figure out how to get Makefile `$(shell pwd)` to work correctly
-    # on FreeBSD, so we can enable this build. All else is working.
-    # - name: x86_64-unknown-freebsd
-    #   environment:
-    #     TRIPLE: x86_64-unknown-freebsd
-    #     DEPS_INSTALL: "\
-    #       pkg update && pkg install -y \
-    #         cmake gmake curl git llvm python3"
-    #   freebsd_instance:
-    #     image: freebsd-13-0-release-amd64
-    #     <<: *hardware_spec
+    - name: x86_64-unknown-freebsd
+      environment:
+        TRIPLE: x86_64-unknown-freebsd
+        DEPS_INSTALL: "\
+          pkg update && pkg install -y \
+            cmake gmake curl git llvm python3"
+      freebsd_instance:
+        image: freebsd-13-0-release-amd64
+        <<: *hardware_spec
 
     - name: x86_64-apple-macosx
       environment:
@@ -90,7 +88,7 @@ task:
   lib_llvm_cache:
     folder: lib/llvm
     fingerprint_script: make llvm-ci-cache-key && printf -- "${VARIANT}"
-    populate_script: sh -c "make llvm NUM_THREADS=${NUM_THREADS} ${MAKE_EXTRA_ARGS}"
+    populate_script: sh -c "make llvm NUM_THREADS=${NUM_THREADS} PWD=$(pwd) ${MAKE_EXTRA_ARGS}"
   upload_caches: [lib_llvm]
 
   archive_script:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ LLVM_SOURCE_ARCHIVE=lib/llvm-$(LLVM_VERSION).src.tar.gz
 LLVM_RELEASE_DIR=lib/llvm-$(LLVM_VERSION)
 LLVM_INSTALL_DIR=lib/llvm
 LLVM_CACHE_BUSTER_DATE=20211203
+PWD?=$(shell pwd)
 
 # By default, use all cores available except one, so things stay responsive.
 NUM_THREADS?=$(shell expr `getconf _NPROCESSORS_ONLN 2>/dev/null` - 1)
@@ -31,7 +32,7 @@ $(LLVM_RELEASE_DIR)/build/CMakeCache.txt: $(LLVM_RELEASE_DIR)
 	mkdir -p $(LLVM_RELEASE_DIR)/build
 	cd $(LLVM_RELEASE_DIR)/build && env CC=clang CXX=clang++ cmake \
 		-DCMAKE_BUILD_TYPE=Release \
-		-DCMAKE_INSTALL_PREFIX=$(shell pwd)/$(LLVM_INSTALL_DIR) \
+		-DCMAKE_INSTALL_PREFIX=$(PWD)/$(LLVM_INSTALL_DIR) \
 		-DCMAKE_OSX_ARCHITECTURES='x86_64;arm64' \
 		-DLIBCLANG_BUILD_STATIC=ON \
 		-DLLVM_ENABLE_BINDINGS=OFF \


### PR DESCRIPTION
This approach uses a workaround for the issue with `$(shell pwd)` inside the `Makefile` on FreeBSD coming up empty.

Instead, with this workaround, we pass in the `pwd` as `PWD` from the outside, explicitly. This allows FreeBSD to successfully install to the intended directory when the build is finished.