### PR TITLE
Update Dockerfile to alpine:3.15 now that it is released.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,7 +36,7 @@ task:
             bash curl coreutils alpine-sdk \
             gcc g++ clang-dev lld xz make cmake linux-headers python3"
       container:
-        image: alpine:edge # TODO: use alpine:3.15 or newest stable release when available
+        image: alpine:3.15
 
     - name: arm64-unknown-linux-musl
       environment:
@@ -46,7 +46,7 @@ task:
             bash curl coreutils alpine-sdk \
             gcc g++ clang-dev lld xz make cmake linux-headers python3"
       container:
-        image: alpine:edge # TODO: use alpine:3.15 or newest stable release when available
+        image: alpine:3.15
 
     - name: x86_64-unknown-freebsd
       environment:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LLVM_BUILD_ARGS?=""
 LLVM_SOURCE_ARCHIVE=lib/llvm-$(LLVM_VERSION).src.tar.gz
 LLVM_RELEASE_DIR=lib/llvm-$(LLVM_VERSION)
 LLVM_INSTALL_DIR=lib/llvm
-LLVM_CACHE_BUSTER_DATE=20211203
+LLVM_CACHE_BUSTER_DATE=20220103
 PWD?=$(shell pwd)
 
 # By default, use all cores available except one, so things stay responsive.


### PR DESCRIPTION
It's better to be pinned to a specific minor version than to be
using `alpine:edge`, but we were formerly on edge because we were
relying on things that were not released yet.