### PR TITLE
Update to LLVM 14.0.3 release.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,6 +11,7 @@ task:
     GITHUB_API_TOKEN: ENCRYPTED[df28a2928d936fa65f97e38a3f2e9fe210f456a3a8ac926896b38eac4b66f8364822593cfd4e69865db5e9fb397472cf]
     CC: clang
     CXX: clang++
+    MAKE: make
     NUM_THREADS: 8
 
   matrix:
@@ -56,6 +57,9 @@ task:
         DEPS_INSTALL: "\
           pkg update && pkg install -y \
             cmake gmake curl git llvm python3"
+        # Without this next environment variable, FreeBSD will run a non-GNU
+        # version of `make` that doesn't interpret our `Makefile` correctly.
+        MAKE: gmake
       freebsd_instance:
         image: freebsd-13-0-release-amd64
         <<: *hardware_spec
@@ -117,8 +121,8 @@ task:
 
   lib_llvm_cache:
     folder: lib/llvm
-    fingerprint_script: make llvm-ci-cache-key && printf -- "${VARIANT}${INDIVIDUAL_CACHE_BUST_DATE}"
-    populate_script: sh -c "make llvm NUM_THREADS=${NUM_THREADS} PWD=$(pwd) ${MAKE_EXTRA_ARGS}"
+    fingerprint_script: ${MAKE} llvm-ci-cache-key && printf -- "${VARIANT}${INDIVIDUAL_CACHE_BUST_DATE}"
+    populate_script: sh -c "${MAKE} llvm NUM_THREADS=${NUM_THREADS} PWD=$(pwd) ${MAKE_EXTRA_ARGS}"
   upload_caches: [lib_llvm]
 
   archive_script:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-LLVM_VERSION=13.0.0
+LLVM_VERSION=14.0.3
 LLVM_DOWNLOAD_URL?="https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LLVM_VERSION)/llvm-project-$(LLVM_VERSION).src.tar.xz"
 LLVM_BUILD_ARGS?=""
-LLVM_SOURCE_ARCHIVE=lib/llvm-$(LLVM_VERSION).src.tar.gz
+LLVM_SOURCE_ARCHIVE=lib/llvm-$(LLVM_VERSION).src.tar.xz
 LLVM_RELEASE_DIR=lib/llvm-$(LLVM_VERSION)
 LLVM_INSTALL_DIR=lib/llvm
 LLVM_CACHE_BUSTER_DATE=20220109


### PR DESCRIPTION
This is the latest available release.

Also, we have observed a presumed LLVM bug on the release we are currently using (13.0.0) wherein, when using the new pass manager, it sometimes generates a function without `retq` instruction, causing the instruction pointer to run straight from one function into the next function defined in the program binary's layout, which has argument-passing invariants violated, causing a segfault.

It's hoped (but not assured) that an LLVM upgrade will fix this bug. We're not sure which version will fix it, so we'll plan to just upgrade to the latest version (14.0.3) and hope for the best.